### PR TITLE
[codex] Use site URL in onboarding prompt

### DIFF
--- a/components/onboarding-prompt.tsx
+++ b/components/onboarding-prompt.tsx
@@ -1,7 +1,17 @@
 import { CopyButton } from "@/components/copy-button";
 import { ONBOARDING_PROMPT } from "@/lib/constants";
+import { getSiteUrl } from "@/lib/env";
+
+function withSiteUrl(prompt: string, siteUrl: string) {
+  const baseUrl = siteUrl.replace(/\/+$/, "");
+  const routePattern = /\/api\/listings(?:\/\{id\}(?:\/deactivate)?)?|\/api\/categories|\/llms\.txt/g;
+
+  return prompt.replace(routePattern, (path) => `${baseUrl}${path}`);
+}
 
 export function OnboardingPrompt() {
+  const prompt = withSiteUrl(ONBOARDING_PROMPT, getSiteUrl());
+
   return (
     <section className="grid gap-4">
       <div className="flex flex-wrap items-center justify-between gap-3">
@@ -9,10 +19,10 @@ export function OnboardingPrompt() {
           <p className="label text-[var(--muted)]">Copy-paste prompt</p>
           <h2 className="text-2xl font-black">Give this to your agent</h2>
         </div>
-        <CopyButton value={ONBOARDING_PROMPT} label="Copy prompt" />
+        <CopyButton value={prompt} label="Copy prompt" />
       </div>
       <pre className="card max-h-[420px] overflow-auto whitespace-pre-wrap p-5 font-mono text-sm leading-6">
-        {ONBOARDING_PROMPT}
+        {prompt}
       </pre>
     </section>
   );


### PR DESCRIPTION
## Summary

- Expands the copy-paste onboarding prompt with the configured site URL from `getSiteUrl()`.
- Keeps `/llms.txt` and API route instructions absolute so pasted agent instructions include the domain and do not require follow-up clarification.

## Validation

- `pnpm lint`
- `pnpm build`

## Notes

The working tree has other pre-existing uncommitted changes that were not included in this branch commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Onboarding prompt now dynamically adjusts API and llms.txt paths to reference your current site URL. The copied prompt content includes properly configured endpoints for your deployment without requiring manual modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->