### PR TITLE
Make listing cards fully clickable

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -113,6 +113,27 @@ a {
     0 14px 40px color-mix(in oklch, var(--paper-shadow) 12%, transparent);
 }
 
+.listing-card {
+  color: inherit;
+  text-decoration: none;
+  transition:
+    transform 180ms ease,
+    border-color 180ms ease,
+    box-shadow 180ms ease;
+}
+
+.listing-card:focus-visible {
+  outline: 3px solid color-mix(in oklch, var(--accent) 72%, transparent);
+  outline-offset: 4px;
+}
+
+.listing-card-cue {
+  transition:
+    transform 180ms ease,
+    background-color 180ms ease,
+    border-color 180ms ease;
+}
+
 .label {
   font-family: var(--font-azeret-mono), ui-monospace, monospace;
   font-size: 0.72rem;
@@ -359,6 +380,12 @@ code {
   a.card:hover {
     transform: translateY(-2px);
     border-color: color-mix(in oklch, var(--accent) 46%, var(--line));
+  }
+
+  .listing-card:hover .listing-card-cue {
+    transform: translate(1px, -1px);
+    border-color: color-mix(in oklch, var(--accent) 52%, var(--line));
+    background: color-mix(in oklch, var(--accent) 10%, var(--panel));
   }
 }
 

--- a/components/listing-card.tsx
+++ b/components/listing-card.tsx
@@ -20,39 +20,45 @@ export function ListingCard({ listing }: { listing: ListingWithSeller }) {
   const Icon = icons[listing.category];
 
   return (
-    <article className="card flex h-full flex-col gap-5 p-5">
-      <div className="flex items-start justify-between gap-4">
-        <div className={`category-mark ${iconTones[listing.category]}`}>
-          <Icon size={20} aria-hidden />
+    <article className="h-full">
+      <Link
+        className="card listing-card flex h-full flex-col gap-5 p-5"
+        href={`/listings/${listing.id}`}
+        aria-label={`Open ${listing.title}`}
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className={`category-mark ${iconTones[listing.category]}`}>
+            <Icon size={20} aria-hidden />
+          </div>
+          <span className="label text-[var(--muted)]">{CATEGORY_LABELS[listing.category]}</span>
         </div>
-        <span className="label text-[var(--muted)]">{CATEGORY_LABELS[listing.category]}</span>
-      </div>
 
-      <div className="flex flex-1 flex-col gap-3">
-        <h2 className="text-xl font-black leading-tight">{listing.title}</h2>
-        <p className="text-sm leading-6 text-[var(--muted)]">{listing.summary}</p>
-      </div>
+        <div className="flex flex-1 flex-col gap-3">
+          <h2 className="text-xl font-black leading-tight">{listing.title}</h2>
+          <p className="text-sm leading-6 text-[var(--muted)]">{listing.summary}</p>
+        </div>
 
-      <div className="flex flex-wrap gap-2">
-        {listing.tags.slice(0, 4).map((tag) => (
-          <span
-            key={tag}
-            className="chip text-xs font-bold"
-          >
-            {tag}
+        <div className="flex flex-wrap gap-2">
+          {listing.tags.slice(0, 4).map((tag) => (
+            <span
+              key={tag}
+              className="chip text-xs font-bold"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+
+        <div className="flex items-center justify-between gap-4 border-t border-[var(--line)] pt-4">
+          <div className="min-w-0">
+            <p className="label text-[var(--muted)]">Seller</p>
+            <p className="truncate text-sm font-bold">{listing.seller?.displayName ?? listing.seller?.pubkey}</p>
+          </div>
+          <span className="button-ghost listing-card-cue shrink-0 !px-3" aria-hidden="true">
+            <ArrowUpRight size={16} aria-hidden />
           </span>
-        ))}
-      </div>
-
-      <div className="flex items-center justify-between gap-4 border-t border-[var(--line)] pt-4">
-        <div className="min-w-0">
-          <p className="label text-[var(--muted)]">Seller</p>
-          <p className="truncate text-sm font-bold">{listing.seller?.displayName ?? listing.seller?.pubkey}</p>
         </div>
-        <Link className="button-ghost shrink-0 !px-3" href={`/listings/${listing.id}`} aria-label={`Open ${listing.title}`}>
-          <ArrowUpRight size={16} aria-hidden />
-        </Link>
-      </div>
+      </Link>
     </article>
   );
 }


### PR DESCRIPTION
## Summary

- Makes the shared listing card render as a full-card `next/link` to the listing detail page.
- Keeps the arrow icon as a non-interactive visual cue instead of the only clickable target.
- Adds listing-card hover and focus-visible styling so mouse and keyboard affordances remain clear.

## Validation

- `pnpm lint`
- `pnpm build`
- Verified rendered `/` and `/listings` markup includes full-card anchors pointing at `/listings/{id}`.