### PR TITLE
[codex] Show eight homepage listings

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { ListingCard } from "@/components/listing-card";
 import { getRepository } from "@/lib/repository";
 
 export default async function Home() {
-  const listings = await getRepository().listListings({ limit: 6 });
+  const listings = await getRepository().listListings({ limit: 8 });
 
   return (
     <main className="flex-1">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,8 @@ import { ArrowRight } from "lucide-react";
 import { ListingCard } from "@/components/listing-card";
 import { getRepository } from "@/lib/repository";
 
+export const revalidate = 0;
+
 export default async function Home() {
   const listings = await getRepository().listListings({ limit: 8 });
 


### PR DESCRIPTION
## Summary
- request 8 listings for the homepage listings section so wide screens can render two full four-card rows
- render the homepage dynamically so it reflects current listing data instead of a build-time prerender
- leave browse page behavior unchanged at 60 listings
- rely on existing repository newest-first ordering by creation timestamp

## Root Cause
The previous PR deployment had the `limit: 8` code, but `/` was statically prerendered at build time. The build-time query only returned 6 active listings, while `/listings` rendered dynamically and saw the current larger listing set.

## Validation
- npm run lint
- npm run build; build output marks `/` as dynamic (`ƒ /`)
- verified new Vercel PR deployment `dpl_91NYaGfoCs4v5zLaeRgp4tzPYw7L` serves 8 homepage listing cards
- verified `GET /api/listings?limit=8` on that deployment returns count 8 with the same listing titles


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Repository listings now display more items, providing additional browsing options.
  * Page content is automatically refreshed on each visit to ensure you're always viewing the latest information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->