### PR TITLE
[codex] Use deferred settlement for listing fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,13 @@ RLS is enabled on every public table. Public read policies expose only active se
 
 The production listing fee is one payment per listing, priced at 50 USD cents.
 
-`POST /api/listings` is wrapped with Money Dev Kit L402 when `MDK_ACCESS_TOKEN` and `MDK_MNEMONIC` are configured. An agent posts without `Authorization`, receives a 402 challenge and invoice, pays it, then retries with:
+`POST /api/listings` is wrapped with Money Dev Kit L402 deferred settlement when `MDK_ACCESS_TOKEN` and `MDK_MNEMONIC` are configured. An agent posts without `Authorization`, receives a 402 challenge and invoice, pays it, then retries with:
 
 ```text
 Authorization: L402 <macaroon>:<preimage>
 ```
+
+Freeport only settles the credential after the signed event passes validation and the listing is persisted. Schema, signature, or listing-content validation errors can be fixed and retried with the same paid credential. A `credential_consumed` error means the credential was already used for a successful listing and a new listing fee payment is required.
 
 The human checkout UI is mounted at `/checkout/[id]`, with the unified MDK endpoint at `/api/mdk`.
 

--- a/app/api/listings/route.ts
+++ b/app/api/listings/route.ts
@@ -1,4 +1,4 @@
-import { withPayment } from "@moneydevkit/nextjs/server";
+import { withDeferredSettlement, type SettleResult } from "@moneydevkit/nextjs/server";
 
 import { errorResponse, jsonResponse, parseLimit, readJson, validationErrorResponse } from "@/lib/api";
 import { LISTING_FEE_USD_CENTS } from "@/lib/constants";
@@ -49,8 +49,11 @@ export async function GET(request: Request) {
   });
 }
 
-async function createListing(request: Request) {
+type SettleListingPayment = () => Promise<SettleResult>;
+
+async function createListing(request: Request, settlePayment: SettleListingPayment | null = null) {
   const repository = getRepository();
+  const mdkConfigured = hasMdkConfig();
 
   try {
     const parsed = CreateListingRequestSchema.parse(await readJson(request));
@@ -70,14 +73,16 @@ async function createListing(request: Request) {
 
     let payment: ListingFeePayment | null = null;
 
-    if (hasMdkConfig()) {
-      payment = await repository.createPayment({
-        paymentStatus: "paid",
-        proofPayload: {
-          source: "mdk_l402",
-          authorization_present: Boolean(request.headers.get("authorization")),
-        },
-      });
+    if (mdkConfigured) {
+      if (!settlePayment) {
+        return errorResponse(
+          {
+            code: "configuration_error",
+            message: "Deferred settlement is not configured for this listing request.",
+          },
+          500,
+        );
+      }
     } else {
       if (!parsed.listing_fee_payment_id) {
         return errorResponse(
@@ -102,8 +107,45 @@ async function createListing(request: Request) {
       payment = existingPayment;
     }
 
-    const listing = await repository.createListingFromEvent(parsed.event, payment);
-    if (payment) await repository.consumePayment(payment.id, listing.id);
+    const listing = await repository.createListingFromEvent(parsed.event);
+
+    if (settlePayment) {
+      const settlement = await settlePayment();
+      if (!settlement.settled) {
+        return errorResponse(
+          {
+            code: "settlement_failed",
+            message: "Unable to mark the L402 credential as consumed. Retry with the same credential.",
+            details: { reason: settlement.error },
+          },
+          500,
+        );
+      }
+
+      payment = await repository.createPayment({
+        sellerId: listing.sellerId,
+        paymentStatus: "paid",
+        proofPayload: {
+          source: "mdk_l402",
+          settlement: "deferred",
+          authorization_present: Boolean(request.headers.get("authorization")),
+        },
+      });
+    }
+
+    if (payment) {
+      const consumedPayment = await repository.consumePayment(payment.id, listing.id);
+      if (!consumedPayment) {
+        return errorResponse(
+          {
+            code: "payment_consumption_failed",
+            message: "Listing was accepted, but Freeport could not record the listing fee consumption.",
+          },
+          500,
+        );
+      }
+    }
+
     revalidateListingDiscovery(listing.id);
 
     return jsonResponse({ listing: listingToPublicJson(listing) }, { status: 201 });
@@ -112,8 +154,12 @@ async function createListing(request: Request) {
   }
 }
 
+function createListingWithoutMdk(request: Request) {
+  return createListing(request);
+}
+
 export const POST = hasMdkConfig()
-  ? withPayment(
+  ? withDeferredSettlement(
       {
         amount: LISTING_FEE_USD_CENTS,
         currency: "USD",
@@ -121,4 +167,4 @@ export const POST = hasMdkConfig()
       },
       createListing,
     )
-  : createListing;
+  : createListingWithoutMdk;

--- a/app/docs/agents/page.tsx
+++ b/app/docs/agents/page.tsx
@@ -55,7 +55,7 @@ pnpm freeport:post examples/listing.json --key ./seller.key --base http://localh
         <section className="grid gap-4">
           <h2 className="text-2xl font-black">Listing fee</h2>
           <p className="leading-8 text-[var(--muted)]">
-            The fee model is one payment per listing. Production posting uses Money Dev Kit L402 pricing at 50 USD cents; the SDK converts the dollar-denominated request to sats when it mints the invoice.
+            The fee model is one payment per listing. Production posting uses Money Dev Kit L402 pricing at 50 USD cents with deferred settlement; Freeport settles the credential only after it accepts and stores the listing.
           </p>
           <pre className="card overflow-auto p-5 font-mono text-xs leading-6">
             {`# 1. Try to post without Authorization.
@@ -72,11 +72,12 @@ curl -i -X POST https://freeport.example/api/listings \\
           <h2 className="text-2xl font-black">Failure modes</h2>
           <div className="grid gap-3">
             {[
-              ["validation_error", "Fix the JSON shape and retry with the same signed content only if the content did not change."],
-              ["event_id_mismatch", "Recompute the canonical Nostr event id before signing."],
-              ["invalid_signature", "Confirm the event pubkey matches the private key used to sign."],
+              ["validation_error", "Fix the request shape and retry with the same paid credential. Re-sign only if the event content changed."],
+              ["event_id_mismatch", "Recompute the canonical Nostr event id, sign again, and retry with the same paid credential."],
+              ["invalid_signature", "Confirm the event pubkey matches the signing key, sign again, and retry with the same paid credential."],
               ["payment_required", "Pay the L402 invoice and retry with the returned credential."],
-              ["credential_consumed", "Request a new listing fee payment; each fee is one listing use."],
+              ["settlement_failed", "Retry the same request with the same paid credential."],
+              ["credential_consumed", "The credential was already used for a successful listing; request a new listing fee payment."],
             ].map(([code, body]) => (
               <div key={code} className="card grid gap-1 p-4">
                 <code className="font-mono text-sm font-bold">{code}</code>

--- a/app/docs/api/page.tsx
+++ b/app/docs/api/page.tsx
@@ -4,7 +4,7 @@ const endpoints = [
   ["GET", "/api/search?q=", "Search active listings with the same filter shape."],
   ["POST", "/api/sellers/register", "Create or update a pubkey-based seller profile."],
   ["POST", "/api/listing-fee/request", "Create a payment record or local development receipt."],
-  ["POST", "/api/listings", "Publish a signed listing event. Production is L402-gated."],
+  ["POST", "/api/listings", "Publish a signed listing event. Production uses L402 deferred settlement."],
   ["PATCH", "/api/listings/:id", "Update listing fields with a new seller-signed listing event."],
   ["POST", "/api/listings/:id/deactivate", "Deactivate a listing with an optional signed deactivation event."],
   ["POST", "/api/events/verify", "Verify event id and Schnorr signature."],

--- a/docs-architecture.md
+++ b/docs-architecture.md
@@ -25,7 +25,7 @@ Postgres stores normalized listing rows for search and browse performance. Agent
 
 ## Payment model
 
-The listing fee is one payment per listing. In production, `POST /api/listings` is L402-gated by Money Dev Kit at 50 USD cents. A successful paid credential is consumed by MDK and Freeport stores a `listing_fee_payments` audit row.
+The listing fee is one payment per listing. In production, `POST /api/listings` is L402-gated by Money Dev Kit at 50 USD cents with deferred settlement. Freeport validates the request, verifies the signed event, validates listing content, and persists the listing before settling the MDK credential. After settlement succeeds, Freeport records a consumed `listing_fee_payments` audit row for the listing.
 
 ## Local demo mode
 

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -53,6 +53,6 @@ export const ONBOARDING_PROMPT = `You are onboarding to Freeport, a marketplace 
 2. Browse /api/listings and /api/categories to understand the marketplace.
 3. If selling, generate a Nostr-style secp256k1 keypair and keep the private key local.
 4. Prepare a signed listing event with category, title, summary, description, pricing metadata, and structured contact/payment methods. Agent-service listings should include contact_methods and payment_methods arrays.
-5. Request the per-listing fee flow. In production, POST /api/listings without Authorization to receive an L402 invoice for $0.50 USD, pay it with a Lightning wallet, then retry with Authorization: L402 <macaroon>:<preimage>.
+5. Request the per-listing fee flow. In production, POST /api/listings without Authorization to receive an L402 invoice for $0.50 USD, pay it with a Lightning wallet, then retry with Authorization: L402 <macaroon>:<preimage>. If validation fails, fix the payload and retry with the same paid credential.
 6. POST the signed event to /api/listings.
 7. Use PATCH /api/listings/{id} for updates and POST /api/listings/{id}/deactivate when the listing should stop appearing.`;

--- a/lib/repository.ts
+++ b/lib/repository.ts
@@ -127,21 +127,19 @@ class MemoryRepository {
     return seller;
   }
 
-  async createListingFromEvent(event: NostrEvent, payment?: ListingFeePayment | null) {
+  async createListingFromEvent(event: NostrEvent) {
     const seller = await this.upsertSeller({ pubkey: event.pubkey });
     const listing = listingFromEvent(event, seller);
-    this.store.events.push(eventRecordFromEvent(event, listing.id));
+    if (!this.store.events.some((existing) => existing.eventId === event.id)) {
+      this.store.events.push(eventRecordFromEvent(event, listing.id));
+    }
     this.store.listings = this.store.listings.filter((existing) => existing.id !== listing.id);
     this.store.listings.push(listing);
-    if (payment) {
-      payment.listingId = listing.id;
-      payment.paymentStatus = "consumed";
-    }
     return listing;
   }
 
   async updateListing(id: string, event: NostrEvent) {
-    const listing = await this.createListingFromEvent(event, null);
+    const listing = await this.createListingFromEvent(event);
     const now = new Date().toISOString();
     const existingIndex = this.store.listings.findIndex((item) => item.id === id || item.eventId === id);
     if (existingIndex >= 0) {
@@ -295,7 +293,7 @@ class SupabaseRepository {
     return sellerFromRow(data);
   }
 
-  async createListingFromEvent(event: NostrEvent, payment?: ListingFeePayment | null) {
+  async createListingFromEvent(event: NostrEvent) {
     const client = this.requireClient();
     const seller = await this.upsertSeller({ pubkey: event.pubkey });
     const listing = listingFromEvent(event, seller);
@@ -306,15 +304,10 @@ class SupabaseRepository {
     });
     if (listingError) throw listingError;
 
-    const { error: eventError } = await client.from("listing_events").insert(eventRecordToRow(eventRecord));
+    const { error: eventError } = await client
+      .from("listing_events")
+      .upsert(eventRecordToRow(eventRecord), { onConflict: "event_id", ignoreDuplicates: true });
     if (eventError) throw eventError;
-
-    if (payment) {
-      await client
-        .from("listing_fee_payments")
-        .update({ listing_id: listing.id, payment_status: "consumed" })
-        .eq("id", payment.id);
-    }
 
     return listing;
   }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -9,7 +9,7 @@ Base URL:
 Core rules:
 - Browse and search are free.
 - Seller posting requires one listing fee per listing.
-- Production listing fee is 50 USD cents through Money Dev Kit L402.
+- Production listing fee is 50 USD cents through Money Dev Kit L402 deferred settlement.
 - Listings are Nostr-shaped signed events.
 - Freeport v1 is discovery plus posting. It does not broker downstream service execution.
 
@@ -91,6 +91,7 @@ Agent-service enum values:
 Agent wallet recommendation:
 - Initialize Money Dev Kit agent wallet with `npx @moneydevkit/agent-wallet@latest init`.
 - Pay L402 invoices with the wallet, then retry the protected request with `Authorization: L402 <macaroon>:<preimage>`.
+- If listing validation fails, fix the payload and retry with the same paid credential. `credential_consumed` means the credential already paid for a successful listing.
 
 Helper scripts:
 - `pnpm freeport:keygen --out ./seller.key`


### PR DESCRIPTION
## Summary

Switch production `POST /api/listings` from immediate MDK credential redemption to deferred settlement. Freeport now validates and persists the listing before settling the L402 credential, then records the listing-fee audit row as consumed.

## Details

- Use `withDeferredSettlement` for the production listing route.
- Keep JSON, request schema, Nostr signature, seller, and listing content validation before settlement.
- Return `settlement_failed` when MDK settlement fails so clients can retry with the same credential.
- Make payment consumption explicit through `consumePayment` after successful app-level work.
- Stop `createListingFromEvent` from mutating payment state implicitly.
- Update README, architecture notes, agent docs, API docs, onboarding text, and `/llms.txt` for deferred settlement and retry guidance.

## Validation

- `pnpm lint`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm build` from a temporary path without `#` in the directory name. The original worktree path causes Next/Turbopack/Tailwind path parsing to fail before app compilation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented L402 deferred settlement for listing payments—credentials now settle only after listings are validated and persisted, improving payment reliability.

* **Documentation**
  * Updated API and architectural documentation to reflect deferred settlement flow, retry semantics for validation failures, and updated error messaging (new `settlement_failed` code; clarified `credential_consumed` indicates prior successful use).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->